### PR TITLE
Add periodicity to fish positions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 code/__pycache__/
+./idea/

--- a/code/agents.py
+++ b/code/agents.py
@@ -98,6 +98,10 @@ class Fish(object):
         self.velocity += ((np.random.rand(1,2)[0] * 2) - 1) * 0.1
         self.velocity = mu.normalize(self.velocity)
         self.position += self.velocity * delta_time * 20
+        x_max = self.environment.boundaries[1]
+        y_max = self.environment.boundaries[3]
+        self.position[0]  = self.position[0] % x_max
+        self.position[1] = self.position[1]  % y_max
         
         try:
             self.sprite.rotation = mu.dir_to_angle(self.velocity)

--- a/code/tests.py
+++ b/code/tests.py
@@ -47,6 +47,27 @@ class TestFishNeigbourhood(unittest.TestCase):
         fishB.position = np.array([[0],[2.01]])       
         fishA.think()
         self.assertNotIn(fishB, fishA.neighbouring_fish)
+    def test_periodicity(self):
+        ann_weights = [np.array([0,0]), np.array([0,0])]
+        boundaries =    [0,10,0,10]               
+        environment = Environment(3, 0, [0,10,0,10], ann_weights)
+        fishA = environment.fish_lst[0]
+
+        x_min = boundaries[0]
+        x_max = boundaries[1]
+        y_min = boundaries[2]
+        y_max = boundaries[3]
+
+        for i in range(0,1000):
+            fishA.advance(1)
+            self.assertTrue(fishA.position[0] >= x_min)
+            self.assertTrue(fishA.position[0] <= x_max)
+            self.assertTrue(fishA.position[1] >= y_min)
+            self.assertTrue(fishA.position[1] <= y_max)
+                        
+        
+        
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fish swim out of view. This poses a problem for visualization as well as clustering since
they are not confined by a space.

Add test for periodicity in tests.py called test_periodicity
that tests if position is without the environment.boundaries